### PR TITLE
Fix Facturama GET catalog requests and bump SDK version to 3.0.7

### DIFF
--- a/facturama/__init__.py
+++ b/facturama/__init__.py
@@ -4,14 +4,13 @@
 
 import base64
 from requests import request
-from simplejson.errors import JSONDecodeError
 
 try:
     import json
 except ImportError:
     import simplejson as json
 
-__version__ = '3.0.6'
+__version__ = '3.0.7'
 __author__ = 'Raul Granados'
 
 api_lite = False


### PR DESCRIPTION
## Bugfix: Facturama catalog requests (Issue #10)

This PR fixes an issue where Facturama catalog endpoints returned
`400 Bad Request` when called from the SDK

### Root causes
- The HTTP client was always sending a request body, even for GET requests.
- Facturama does not accept a body in GET requests and returns HTML error pages.
- JSON parsing was not robust against non-JSON responses.

### Fixes
- Payload is now sent **only** for `POST`, `PUT` and `PATCH` requests.
- GET requests rely exclusively on query parameters.
- Response parsing now checks `Content-Type` and safely falls back to text/HTML.

---

## Version update

- SDK version bumped from **3.0.6 → 3.0.7**

---

## Issue tracking

Closes #10

---

## Backward compatibility

No breaking changes were introduced. This release only improves request
correctness and error handling stability.